### PR TITLE
Switched to JUnit 4 instead of 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,36 +9,29 @@ An indoors localization project that aims to locate the users on a college campu
 ## Development Environment Setup
 
 ### Eclipse
-Tested in Eclipse Oxygen.2 (4.7.2) - latest version at time of writing
+Tested in Eclipse Oxygen.3 (4.7.3) - latest version at time of writing
 
 1. Clone files from Git repository using terminal
-1. Create new project in Eclipse
-1. Name ROCate
-1. Uncheck "use default location"
-1. Select root directory of project on your filesystem (the directory containing README.md and src/)
-1. Hit finish
-1. Open src/Coordinates2DTest.java
-1. Hover over first error (line 1)
-1. Select 3rd option (fix project setup)
-1. Hit OK in dialog box
+1. Open Eclipse Marketplace (under help menu on macOS), search "buildship", and install if not already installed.
+1. In eclipse, click File, Import, then select Gradle, Existing Gradle Project
+1. Click Next at the wizard
+1. Click browse, navigate to the root folder of the repo you cloned, hit open
+1. Click Finish.
+
 
 Now you have the project properly imported, set up, and you can run the tests.
 
 
 ### IntelliJ IDEA
-Tested in IDEA Ultimate 2017.3 - latest version at time of writing. You can get Ultimate for free as a student. These instructions should also work for Community Edition (free to all).
-
+Tested in IDEA Ultimate 2018.1 - latest version at time of writing. You can get Ultimate for free as a student. These instructions should also work for Community Edition (free to all).
 
 1. Clone files from Git repository using terminal
-1. Open IDEA, hit File > Open
-1. Navigate to the ROCate directory you cloned
-1. Open src/Coordinates2DTest.java
-1. Select "junit" on line 1 (will be highlighted red because of error)
-1. Activate contextual menu (option-Enter on Mac)
-1. Select "Add JUnit5.0 to classpath"
-1. Hit OK
+1. In IDEA, click File, Open, then navigate to root folder of cloned repo and hit open
+1. A little notification box will pop up in the bottom right asking if you want to import gradle project. Select Import Gradle Project.
+1. Check "use auto-import"
+1. Click ok
 
 Now you have the project properly imported, set up, and you can run the tests. You may get some warnings thrown when you run the tests, but they do run and you can see the results in the test GUI.
 
 ## Trilateration Algorithm
-Since the development of the Trilateration algorithm will require MTH 165, [here is an algorithm](https://github.com/lemmingapex/trilateration)
+Since the development of the Trilateration algorithm will require MTH 165, we will use this [library](https://github.com/lemmingapex/trilateration) instead. This is already configured for you in the gradle project.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Tested in IDEA Ultimate 2018.1 - latest version at time of writing. You can get 
 1. Check "use auto-import"
 1. Click ok
 
-Now you have the project properly imported, set up, and you can run the tests. You may get some warnings thrown when you run the tests, but they do run and you can see the results in the test GUI.
+Now you have the project properly imported, set up, and you can run the tests.
 
 ## Trilateration Algorithm
 Since the development of the Trilateration algorithm will require MTH 165, we will use this [library](https://github.com/lemmingapex/trilateration) instead. This is already configured for you in the gradle project.

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ repositories {
 }
 
 dependencies {
-    testCompile("org.junit.jupiter:junit-jupiter-api:5.1.0")
+    testCompile("junit:junit:4.12")
     testCompile("com.lemmingapex.trilateration:trilateration:1.0.2")
+    compile("com.lemmingapex.trilateration:trilateration:1.0.2")
 }

--- a/src/main/java/Coordinates2D.java
+++ b/src/main/java/Coordinates2D.java
@@ -1,5 +1,6 @@
 import com.lemmingapex.trilateration.NonLinearLeastSquaresSolver;
 
+
 /*
 This class describes a 2D set of coordinates and provides helpful methods for dealing with their geometry
  */

--- a/src/test/java/Coordinates2DTest.java
+++ b/src/test/java/Coordinates2DTest.java
@@ -1,26 +1,28 @@
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import org.junit.Before;
 
-class Coordinates2DTest {
+public class Coordinates2DTest {
     //We will use these in both methods so they are instance variables
     private Coordinates2D testObj1;
     private Coordinates2D testObj2;
 
-    @org.junit.jupiter.api.BeforeEach
-    void setUp() {
+    @Before
+    public void setUp() {
         //Set up the test circles
         testObj1 = new Coordinates2D(5, 5, 4,4);
         testObj2 = new Coordinates2D(3,3,4,4);
     }
 
-    @org.junit.jupiter.api.Test
-    void distance() {
+    @Test
+    public void distance() {
         double distance = testObj1.distance(testObj2);
         double expected = 2 * Math.sqrt(2);
         assertEquals(expected, distance, 0.001);
     }
 
-    @org.junit.jupiter.api.Test
-    void circleIntersectionIntersects() throws Exception {
+    @Test
+    public void circleIntersectionIntersects() throws Exception {
         //testObj1 and testObj2 should intersect
         //Test that they do
         Coordinates2D intersection = testObj1.circleIntersection(testObj2);
@@ -30,14 +32,14 @@ class Coordinates2DTest {
 
     }
 
-    @org.junit.jupiter.api.Test
-    void circleIntersectionNoIntersects() {
+    @Test
+    public void circleIntersectionNoIntersects() {
         //Test another case, where the circles do not intersect
         Coordinates2D testObj3 = new Coordinates2D(50,50,1,2);
         Coordinates2D intersectionResult = testObj2.circleIntersection(testObj3);
         
-        assertEquals(Double.NaN, intersectionResult.getX());
-        assertEquals(Double.NaN, intersectionResult.getY());
+        assertEquals(Double.NaN, intersectionResult.getX(), 0.0000001);
+        assertEquals(Double.NaN, intersectionResult.getY(), 0.0000001);
     }
 
 }


### PR DESCRIPTION
In order to make everything work seamlessly for new people downloading the project and getting set up, I had to switch to using JUnit 4 tests so that they would run better (or run at all) in Eclipse without everyone having to mess around with adding/downloading libraries from external sources. Now, everything is handled by gradle (as it should be) and tests run and work in both IDEs. 